### PR TITLE
Fix fzf issue when using ZSH as default shell

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -271,4 +271,7 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 
+# fzf
+[ -f ~/.fzf.bash ] && source ~/.fzf.bash
+
 source "$HOME/.utils"

--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -203,7 +203,7 @@
   insteadOf = "gist:"
 
 [user]
-	name = Massamba Sow
-	email = mass.sow@gmail.com
+	name = msict4d
+	email = ms.ict4d@gmail.com
 [credential]
 	helper = store

--- a/dotfiles/.gitconfig.user
+++ b/dotfiles/.gitconfig.user
@@ -1,3 +1,3 @@
 [user]
-	name = Massamba Sow
-	email = mass.sow@gmail.com
+	name = msict4d
+	email = ms.ict4d@gmail.com

--- a/dotfiles/.utils
+++ b/dotfiles/.utils
@@ -26,6 +26,3 @@ if command -v brew >/dev/null 2>&1; then
 	# Load rupa's z if installed
 	[ -f $(brew --prefix)/etc/profile.d/z.sh ] && source $(brew --prefix)/etc/profile.d/z.sh
 fi
-
-# fzf
-[ -f ~/.fzf.bash ] && source ~/.fzf.bash


### PR DESCRIPTION
In commit b58b6b, moving the line:
```bash 
# fzf
[ -f ~/.fzf.bash ] && source ~/.fzf.bash 
```
from .bashrc to .utils created a warning in WSL (bind command not found). 
Reverting it in .bashrc